### PR TITLE
Correct some german translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## version 1.2.2 (April 10, 2018)
+
+- corrected some german translations
+
 ## version 1.2.1 (January 26, 2016)
 
 - the list is now [available on GitHub](https://github.com/stefangabos/world_countries)

--- a/data/de/countries.csv
+++ b/data/de/countries.csv
@@ -241,7 +241,7 @@ id,name,alpha2,alpha3
 862,Venezuela,ve,ven
 784,"Vereinigte Arabische Emirate",ae,are
 840,"Vereinigte Staaten von Amerika",us,usa
-826,"Vereinigtes Königreich Großbritannien und Nordirland",gb,gbr
+826,"Vereinigtes Königreich",gb,gbr
 704,Vietnam,vn,vnm
 876,"Wallis und Futuna",wf,wlf
 162,Weihnachtsinsel,cx,cxr

--- a/data/de/countries.csv
+++ b/data/de/countries.csv
@@ -86,7 +86,7 @@ id,name,alpha2,alpha3
 360,Indonesien,id,idn
 833,"Insel Man",im,imn
 368,Irak,iq,irq
-364,"Iran, Islamische Republik",ir,irn
+364,"Iran",ir,irn
 372,Irland,ie,irl
 352,Island,is,isl
 376,Israel,il,isr

--- a/data/de/countries.csv
+++ b/data/de/countries.csv
@@ -189,7 +189,7 @@ id,name,alpha2,alpha3
 678,"São Tomé und Príncipe",st,stp
 682,Saudi-Arabien,sa,sau
 752,Schweden,se,swe
-756,"Schweiz (Confoederatio Helvetica)",ch,che
+756,"Schweiz",ch,che
 686,Senegal,sn,sen
 688,Serbien,rs,srb
 690,Seychellen,sc,syc

--- a/data/de/countries.json
+++ b/data/de/countries.json
@@ -240,7 +240,7 @@
 {"id":862,"name":"Venezuela","alpha2":"ve","alpha3":"ven"},
 {"id":784,"name":"Vereinigte Arabische Emirate","alpha2":"ae","alpha3":"are"},
 {"id":840,"name":"Vereinigte Staaten von Amerika","alpha2":"us","alpha3":"usa"},
-{"id":826,"name":"Vereinigtes Königreich Großbritannien und Nordirland","alpha2":"gb","alpha3":"gbr"},
+{"id":826,"name":"Vereinigtes Königreich","alpha2":"gb","alpha3":"gbr"},
 {"id":704,"name":"Vietnam","alpha2":"vn","alpha3":"vnm"},
 {"id":876,"name":"Wallis und Futuna","alpha2":"wf","alpha3":"wlf"},
 {"id":162,"name":"Weihnachtsinsel","alpha2":"cx","alpha3":"cxr"},

--- a/data/de/countries.json
+++ b/data/de/countries.json
@@ -188,7 +188,7 @@
 {"id":678,"name":"São Tomé und Príncipe","alpha2":"st","alpha3":"stp"},
 {"id":682,"name":"Saudi-Arabien","alpha2":"sa","alpha3":"sau"},
 {"id":752,"name":"Schweden","alpha2":"se","alpha3":"swe"},
-{"id":756,"name":"Schweiz (Confoederatio Helvetica)","alpha2":"ch","alpha3":"che"},
+{"id":756,"name":"Schweiz","alpha2":"ch","alpha3":"che"},
 {"id":686,"name":"Senegal","alpha2":"sn","alpha3":"sen"},
 {"id":688,"name":"Serbien","alpha2":"rs","alpha3":"srb"},
 {"id":690,"name":"Seychellen","alpha2":"sc","alpha3":"syc"},

--- a/data/de/countries.json
+++ b/data/de/countries.json
@@ -85,7 +85,7 @@
 {"id":360,"name":"Indonesien","alpha2":"id","alpha3":"idn"},
 {"id":833,"name":"Insel Man","alpha2":"im","alpha3":"imn"},
 {"id":368,"name":"Irak","alpha2":"iq","alpha3":"irq"},
-{"id":364,"name":"Iran, Islamische Republik","alpha2":"ir","alpha3":"irn"},
+{"id":364,"name":"Iran","alpha2":"ir","alpha3":"irn"},
 {"id":372,"name":"Irland","alpha2":"ie","alpha3":"irl"},
 {"id":352,"name":"Island","alpha2":"is","alpha3":"isl"},
 {"id":376,"name":"Israel","alpha2":"il","alpha3":"isr"},

--- a/data/de/countries.sql
+++ b/data/de/countries.sql
@@ -98,7 +98,7 @@ INSERT INTO `countries` (`id`, `name`, `alpha_2`, `alpha_3`) VALUES
 (360,'Indonesien','id','idn'),
 (833,'Insel Man','im','imn'),
 (368,'Irak','iq','irq'),
-(364,'Iran, Islamische Republik','ir','irn'),
+(364,'Iran','ir','irn'),
 (372,'Irland','ie','irl'),
 (352,'Island','is','isl'),
 (376,'Israel','il','isr'),

--- a/data/de/countries.sql
+++ b/data/de/countries.sql
@@ -253,7 +253,7 @@ INSERT INTO `countries` (`id`, `name`, `alpha_2`, `alpha_3`) VALUES
 (862,'Venezuela','ve','ven'),
 (784,'Vereinigte Arabische Emirate','ae','are'),
 (840,'Vereinigte Staaten von Amerika','us','usa'),
-(826,'Vereinigtes Königreich Großbritannien und Nordirland','gb','gbr'),
+(826,'Vereinigtes Königreich','gb','gbr'),
 (704,'Vietnam','vn','vnm'),
 (876,'Wallis und Futuna','wf','wlf'),
 (162,'Weihnachtsinsel','cx','cxr'),

--- a/data/de/countries.sql
+++ b/data/de/countries.sql
@@ -201,7 +201,7 @@ INSERT INTO `countries` (`id`, `name`, `alpha_2`, `alpha_3`) VALUES
 (678,'São Tomé und Príncipe','st','stp'),
 (682,'Saudi-Arabien','sa','sau'),
 (752,'Schweden','se','swe'),
-(756,'Schweiz (Confoederatio Helvetica)','ch','che'),
+(756,'Schweiz','ch','che'),
 (686,'Senegal','sn','sen'),
 (688,'Serbien','rs','srb'),
 (690,'Seychellen','sc','syc'),


### PR DESCRIPTION
Currently the german translations are using the long form of country names. In my opinion it's cleaner and better to have the short instead of the long forms.
This PR corrects some of these cases, but I most likely didn't catch everything.

For reference: https://de.wikipedia.org/wiki/Liste_der_Staaten_der_Erde