### PR TITLE
German countries.json contains hidden Unicode char

### DIFF
--- a/data/de/countries.json
+++ b/data/de/countries.json
@@ -189,5 +189,5 @@
 {"id":840,"name":"Vereinigte Staaten","alpha2":"us","alpha3":"usa"},
 {"id":826,"name":"Vereinigtes Königreich","alpha2":"gb","alpha3":"gbr"},
 {"id":704,"name":"Vietnam","alpha2":"vn","alpha3":"vnm"},
-{"id":140,"name":"Zentral­afrikanische Republik","alpha2":"cf","alpha3":"caf"},
+{"id":140,"name":"Zentralafrikanische Republik","alpha2":"cf","alpha3":"caf"},
 {"id":196,"name":"Zypern","alpha2":"cy","alpha3":"cyp"}]


### PR DESCRIPTION
Country "CF" ("Zentralafrikanische Republik") contains a hidden Unicode char (U+00AD) that may cause problems on some systems. The char has been removed.